### PR TITLE
Updated to default installation to GKE 1.20

### DIFF
--- a/gke/cluster.tf
+++ b/gke/cluster.tf
@@ -61,9 +61,9 @@ resource "google_container_cluster" "cluster" {
   }
 
   master_auth {
-#     Not supported for GKE >= 1.19
-#     username = var.gke_username
-#     password = var.gke_password
+    #     Not supported for GKE >= 1.19
+    #     username = var.gke_username
+    #     password = var.gke_password
 
     client_certificate_config {
       issue_client_certificate = false

--- a/gke/cluster.tf
+++ b/gke/cluster.tf
@@ -61,8 +61,9 @@ resource "google_container_cluster" "cluster" {
   }
 
   master_auth {
-    username = var.gke_username
-    password = var.gke_password
+#     Not supported for GKE >= 1.19
+#     username = var.gke_username
+#     password = var.gke_password
 
     client_certificate_config {
       issue_client_certificate = false

--- a/gke/variables.tf
+++ b/gke/variables.tf
@@ -24,23 +24,25 @@ variable "region" {
   description = "The GCP region"
 }
 
-variable "gke_username" {
-  type        = string
-  description = "The cluster master username"
-}
+# Not supported for GKE >= 1.19
+# variable "gke_username" {
+#   type        = string
+#   description = "The cluster master username"
+# }
 
-variable "gke_password" {
-  type        = string
-  description = "The cluster master password"
+# Not supported for GKE >= 1.19
+# variable "gke_password" {
+#   type        = string
+#   description = "The cluster master password"
 
-  validation {
-    condition     = length(var.gke_password) >= 16
-    error_message = "The cluster master passsword must be 16 characters or more."
-  }
-}
+#   validation {
+#     condition     = length(var.gke_password) >= 16
+#     error_message = "The cluster master passsword must be 16 characters or more."
+#   }
+# }
 
 variable "k8s_version" {
-  default     = "1.17"
+  default     = "1.20" # latest supported version of GKE as of 2021-09-28
   type        = string
   description = "The version of Kubernetes"
 }


### PR DESCRIPTION
## Description

<!--- Describe your changes in detail -->
- Removed GKE Username and Password as not supported for GKE >= 0.19
- Set to deploy GKE 1.20 as the defaulted version

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- The current version of GKE deployed in is no longer available in all regions.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I've ran through a Terraform deployment.

## Screenshots (if appropriate)

<!--- Drag any screenshots here or delete this section -->
N/A

## Types of changes

<!--- What types of changes does your code introduce? -->
<!--- PICK ONE: -->

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [x] All new and existing tests passed.
